### PR TITLE
Add resource directory "res" to maven resources

### DIFF
--- a/FactorioBlueprintStringRenderer/pom.xml
+++ b/FactorioBlueprintStringRenderer/pom.xml
@@ -17,6 +17,11 @@
 				</configuration>
 			</plugin>
 		</plugins>
+		<resources>
+			<resource>
+				<directory>res</directory>
+			</resource>
+		</resources>
 	</build>
 	<repositories>
 		<repository>


### PR DESCRIPTION
To include the resources from the "res" folder in the jar from a cmd line maven build, this change instructs maven to do so.

Cheers