### PR TITLE
added key format for self connected combinators

### DIFF
--- a/FactorioBlueprintStringRenderer/src/com/demod/fbsr/EntityRendererFactory.java
+++ b/FactorioBlueprintStringRenderer/src/com/demod/fbsr/EntityRendererFactory.java
@@ -393,7 +393,9 @@ public class EntityRendererFactory {
 							int targetEntityId = wireJson.getInt("entity_id");
 
 							String key;
-							if (entityId < targetEntityId) {
+							if (entityId == targetEntityId) {
+								key = entityId + "|" + colorName;
+							} else if (entityId < targetEntityId) {
 								key = entityId + "|" + circuitId + "|" + targetEntityId + "|" + targetCircuitId + "|"
 										+ colorName;
 							} else {


### PR DESCRIPTION
fix for #118 

I have tested this with:

- the blueprint from that issue
- a combinator with both red and green cables connected
`0eNqNUc1ugzAMfhefs6l0LWyobzJNKCReZwkcZEI1hPLuc8IOPW29RLL9/eSzN+iHBSchjtBuQC7wDO37BjNd2Q65F9cJoQWKOIIBtmOuPDryKE8ujD2xjUEgGSD2+A1tlT4MIEeKhLtaKdaOl7FHUcBfOgamMCs1cHZXuZeqNrAq61A/n9XFk6Db50cD+uMoYeh6/LI3Ur6SflU7nfmiNOduzhZtDnrItHGyUgxbuEBuTKsSFo7dp4SxI54WhUZZMKViw7tr0aryI+jv05EvyRyJWyiW8pg3cRVE/h+oJsfHVKtHVRWYUgaX47V3tzZwQ5n3Hb5Wp+b01tSNLvhcp/QDdtC01w==`

- [a generic, bigger blueprint](https://cdn.discordapp.com/attachments/783049079584063588/797471027558744074/message.txt)

It is literally the first time I look at this repo so even though those three tests worked, it might still fail somewhere.